### PR TITLE
Fix OauthPlugin query aggregation always being default

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -155,7 +155,8 @@ class OauthPlugin implements EventSubscriberInterface
         $params = $this->prepareParameters($params);
 
         // Build signing string from combined params
-        $parameterString = new QueryString($params);
+        $parameterString = clone $request->getQuery();
+        $parameterString->replace($params);
 
         $url = Url::factory($request->getUrl())->setQuery('')->setFragment(null);
 

--- a/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
+++ b/tests/Guzzle/Tests/Plugin/Oauth/OauthPluginTest.php
@@ -3,6 +3,7 @@
 namespace Guzzle\Tests\Plugin\Oauth;
 
 use Guzzle\Http\Message\RequestFactory;
+use Guzzle\Http\QueryAggregator\CommaAggregator;
 use Guzzle\Plugin\Oauth\OauthPlugin;
 use Guzzle\Common\Event;
 
@@ -147,6 +148,21 @@ class OauthPluginTest extends \Guzzle\Tests\GuzzleTestCase
         $request = $this->getRequest();
         $request->getQuery()->set('a', array('b' => array('e' => 'f', 'c' => 'd')));
         $this->assertContains('a%255Bb%255D%255Bc%255D%3Dd%26a%255Bb%255D%255Be%255D%3Df%26c%3Dd%26e%3Df%26', $p->getStringToSign($request, self::TIMESTAMP, self::NONCE));
+    }
+
+    /**
+     * @depends testMultiDimensionalArray
+     */
+    public function testMultiDimensionalArrayWithNonDefaultQueryAggregator()
+    {
+        $p = new OauthPlugin($this->config);
+        $request = $this->getRequest();
+        $aggregator = new CommaAggregator();
+        $query = $request->getQuery()->setAggregator($aggregator)
+            ->set('g', array('h', 'i', 'j'))
+            ->set('k', array('l'))
+            ->set('m', array('n', 'o'));
+        $this->assertContains('a%3Db%26c%3Dd%26e%3Df%26g%3Dh%2Ci%2Cj%26k%3Dl%26m%3Dn%2Co', $p->getStringToSign($request, self::TIMESTAMP, self::NONCE));
     }
 
     /**


### PR DESCRIPTION
This is the same as guzzle/guzzle#596, but submitted to the correct repository for Guzzle 3. Here's what I wrote there describing the issue:

> When using OauthPlugin for a request with a non-default query aggregator set (e.g. CommaAggregator), it creates invalid OAuth signatures. This is because it uses the default query aggregator to construct the "string to sign". The string to sign then contains the query string parameters in a different format to the actual query string of the request:
> 
> Request URI: http://example.com/test?a=b,c,d
> OAuth string to sign (un-escaped): GET&http://example.com/test&a[0]=b&a[1]=c&a[2]=d...

I took @mtdowling's advice, and this time avoided a `QueryString::getAggregator()` method. Instead I clone the entire `QueryString` from the request, then replace its data with the parameters to be signed.

It's a bit dirty as it unnecessarily subjects the `oauth_*` parameters to the query aggregation strategy of the request's `QueryString`. However, there should be no effects of this -- because these never have arrays as their value, they will never be subjected to aggregation anyway. If this approach is also undesirable, I'll probably need to hand the implementation over to a maintainer as I don't think I'll have the time to do a more significant refactoring.
