### PR TITLE
fix php version issue from ErrorResponsePlugin

### DIFF
--- a/src/Guzzle/Plugin/ErrorResponse/ErrorResponsePlugin.php
+++ b/src/Guzzle/Plugin/ErrorResponse/ErrorResponsePlugin.php
@@ -62,8 +62,11 @@ class ErrorResponsePlugin implements EventSubscriberInterface
                 $errorClassInterface = __NAMESPACE__ . '\\ErrorResponseExceptionInterface';
                 if (!class_exists($className)) {
                     throw new ErrorResponseException("{$className} does not exist");
-                } elseif (!is_subclass_of($className, $errorClassInterface)) {
-                    throw new ErrorResponseException("{$className} must implement {$errorClassInterface}");
+                } else {
+                    $reflection = new \ReflectionClass($className);
+                    if (!$reflection->implementsInterface($errorClassInterface)) {
+                        throw new ErrorResponseException("{$className} must implement {$errorClassInterface}");
+                    }
                 }
                 throw $className::fromCommand($command, $response);
             }


### PR DESCRIPTION
The method used for verifying that a class implementes an interface (is_subclass_of) did not worked with interfaces before php 5.3.7
