### PR TITLE
Use the $extras argument as a $context parameter

### DIFF
--- a/src/Guzzle/Log/MonologLogAdapter.php
+++ b/src/Guzzle/Log/MonologLogAdapter.php
@@ -29,6 +29,6 @@ class MonologLogAdapter extends AbstractLogAdapter
 
     public function log($message, $priority = LOG_INFO, $extras = array())
     {
-        $this->log->addRecord(self::$mapping[$priority], $message);
+        $this->log->addRecord(self::$mapping[$priority], $message, $extras);
     }
 }


### PR DESCRIPTION
Useful for providing dynamic data while keeping the same $message for several events.
