### PR TITLE
fix php version issue #14 from ErrorResponsePlugin

### DIFF
--- a/src/Guzzle/Plugin/ErrorResponse/ErrorResponsePlugin.php
+++ b/src/Guzzle/Plugin/ErrorResponse/ErrorResponsePlugin.php
@@ -62,7 +62,7 @@ class ErrorResponsePlugin implements EventSubscriberInterface
                 $errorClassInterface = __NAMESPACE__ . '\\ErrorResponseExceptionInterface';
                 if (!class_exists($className)) {
                     throw new ErrorResponseException("{$className} does not exist");
-                } elseif (!is_subclass_of($className, $errorClassInterface)) {
+                } elseif (!(in_array($errorClassInterface, class_implements($className)))) {
                     throw new ErrorResponseException("{$className} must implement {$errorClassInterface}");
                 }
                 throw $className::fromCommand($command, $response);


### PR DESCRIPTION
A new way to check the class implements the ErrorResponseExceptionInterface (previous method "is_subclass_of" did not worked with interfaces before php 5.3.7)
