### PR TITLE
Remove unneeded reset() in ResourceIteratorTest

### DIFF
--- a/tests/Guzzle/Tests/Service/Resource/ResourceIteratorTest.php
+++ b/tests/Guzzle/Tests/Service/Resource/ResourceIteratorTest.php
@@ -66,7 +66,6 @@ class ResourceIteratorTest extends \Guzzle\Tests\GuzzleTestCase
         ));
 
         $d = array();
-        reset($ri);
         foreach ($ri as $data) {
             $d[] = $data;
         }


### PR DESCRIPTION
- it's plain unneeded - foreach calls rewind() on the iterator anyway
- as it's not an ArrayIterator or array, it actually doesn't call rewind() - it resets the array pointer for the internal property list
- This is a known wontfix HHVM incompatibility
