### PR TITLE
Sort using using lexicographical byte value ordering

### DIFF
--- a/src/Guzzle/Plugin/Oauth/OauthPlugin.php
+++ b/src/Guzzle/Plugin/Oauth/OauthPlugin.php
@@ -226,7 +226,7 @@ class OauthPlugin implements EventSubscriberInterface
 
         // Sort params
         $params = $params->toArray();
-        ksort($params);
+        uksort($params, 'strcmp');
 
         return $params;
     }


### PR DESCRIPTION
See 9.1.1 in http://oauth.net/core/1.0/

> Parameters are sorted by name, using lexicographical byte value ordering.

This is already fixed in Guzzle4, but a patch to Guzzle3 would be appreciated, as I encountered this bug, in my case when posting an array with more then 9 items.
Also see https://github.com/guzzle/guzzle/issues/558 and #4
