### PR TITLE
[Http][Message] Add entity body support for options request

### DIFF
--- a/src/Guzzle/Http/Message/RequestFactory.php
+++ b/src/Guzzle/Http/Message/RequestFactory.php
@@ -84,7 +84,7 @@ class RequestFactory implements RequestFactoryInterface
     {
         $method = strtoupper($method);
 
-        if ($method == 'GET' || $method == 'HEAD' || $method == 'TRACE' || $method == 'OPTIONS') {
+        if ($method == 'GET' || $method == 'HEAD' || $method == 'TRACE') {
             // Handle non-entity-enclosing request methods
             $request = new $this->requestClass($method, $url, $headers);
             if ($body) {

--- a/tests/Guzzle/Tests/Http/Message/RequestFactoryTest.php
+++ b/tests/Guzzle/Tests/Http/Message/RequestFactoryTest.php
@@ -93,7 +93,7 @@ class HttpRequestFactoryTest extends \Guzzle\Tests\GuzzleTestCase
     {
         $request = RequestFactory::getInstance()->create('OPTIONS', 'http://www.example.com/');
         $this->assertEquals('OPTIONS', $request->getMethod());
-        $this->assertInstanceOf('Guzzle\\Http\\Message\\Request', $request);
+        $this->assertInstanceOf('Guzzle\\Http\\Message\\EntityEnclosingRequest', $request);
     }
 
     public function testCreatesNewPutRequestWithBody()


### PR DESCRIPTION
Hey!

This PR adds the entity body support for options request. According to the [RFC-2616 Section 9.2](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.2), the options request can wraps an entity body.
