### PR TITLE
Fix documentation about error responses

### DIFF
--- a/docs/_downloads/guzzle-schema-1.0.json
+++ b/docs/_downloads/guzzle-schema-1.0.json
@@ -71,7 +71,7 @@
                             "type": "number",
                             "description": "HTTP response status code of the error"
                         },
-                        "phrase": {
+                        "reason": {
                             "type": "string",
                             "description": "Response reason phrase or description of the error"
                         },

--- a/docs/webservice-client/guzzle-service-descriptions.rst
+++ b/docs/webservice-client/guzzle-service-descriptions.rst
@@ -99,7 +99,7 @@ endpoint and HTTP method. If an API has a ``DELETE /users/:id`` operation, a sat
                     "errorResponses": [
                         {
                             "code": 500,
-                            "phrase": "Unexpected Error",
+                            "reason": "Unexpected Error",
                             "class": "string"
                         }
                     ],
@@ -125,7 +125,7 @@ endpoint and HTTP method. If an API has a ``DELETE /users/:id`` operation, a sat
     "responseNotes", "string", "A description of the response returned by the operation"
     "responseType", "string", "The type of response that the operation creates: one of primitive, class, model, or documentation. If not specified, this value will be automatically inferred based on whether or not there is a model matching the name, if a matching class name is found, or set to 'primitive' by default."
     "deprecated", "boolean", "Whether or not the operation is deprecated"
-    "errorResponses", "array", "Errors that could occur while executing the operation. Each item of the array is an object that can contain a 'code' (HTTP response status code of the error), 'phrase' (reason phrase or description of the error), and 'class' (an exception class that will be raised when this error is encountered)"
+    "errorResponses", "array", "Errors that could occur while executing the operation. Each item of the array is an object that can contain a 'code' (HTTP response status code of the error), 'reason' (reason phrase or description of the error), and 'class' (an exception class that will be raised when this error is encountered)"
     "data", "object", "Any arbitrary data to associate with the operation"
     "parameters", "object containing :ref:`parameter-schema` objects", "Parameters of the operation. Parameters are used to define how input data is serialized into a HTTP request."
     "additionalParameters", "A single :ref:`parameter-schema` object", "Validation and serialization rules for any parameter supplied to the operation that was not explicitly defined."
@@ -232,7 +232,7 @@ errorResponses
 
 ``errorResponses`` is an array containing objects that define the errors that could occur while executing the
 operation. Each item of the array is an object that can contain a 'code' (HTTP response status code of the error),
-'phrase' (reason phrase or description of the error), and 'class' (an exception class that will be raised when this
+'reason' (reason phrase or description of the error), and 'class' (an exception class that will be raised when this
 error is encountered).
 
 ErrorResponsePlugin
@@ -246,7 +246,7 @@ checked against the list of error responses for an exact match using the followi
 
 1. Does the errorResponse have a defined ``class``?
 2. Is the errorResponse ``code`` equal to the status code of the response?
-3. Is the errorResponse ``phrase`` equal to the reason phrase of the response?
+3. Is the errorResponse ``reason`` equal to the reason phrase of the response?
 4. Throw the exception stored in the ``class`` attribute of the errorResponse.
 
 The ``class`` attribute must point to a class that implements

--- a/src/Guzzle/Service/Description/Operation.php
+++ b/src/Guzzle/Service/Description/Operation.php
@@ -86,7 +86,7 @@ class Operation implements OperationInterface
      *                       name, if a matching PSR-0 compliant class name is found, or set to 'primitive' by default.
      * - deprecated:         (bool) Set to true if this is a deprecated command
      * - errorResponses:     (array) Errors that could occur when executing the command. Array of hashes, each with a
-     *                       'code' (the HTTP response code), 'phrase' (response reason phrase or description of the
+     *                       'code' (the HTTP response code), 'reason' (response reason phrase or description of the
      *                       error), and 'class' (a custom exception class that would be thrown if the error is
      *                       encountered).
      * - data:               (array) Any extra data that might be used to help build or serialize the operation


### PR DESCRIPTION
It looks like in the `ErrorResponsePlugin` the key used for the error message is `reason` while it is documented as `phrase`.
