### PR TITLE
Define composer test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_script:
   - composer install --no-interaction --prefer-source --dev
   - ~/.nvm/nvm.sh install v0.6.14
 
-script: vendor/bin/phpunit
+script: composer test

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,10 @@
         }
     },
 
+    "scripts": {
+        "test": "phpunit"
+    },
+
     "require-dev": {
         "doctrine/cache": "~1.3",
         "symfony/class-loader": "~2.1",


### PR DESCRIPTION
The composer test script is an easy and convenient way to define your unit
testing scripts. It makes testing your library as easy as just running
`composer test`.

For more information about the `scripts` field check out [the manual](https://getcomposer.org/doc/articles/scripts.md) and [this blog post](http://maxgfeller.com/blog/2014/07/22/composer-test/).
