### PR TITLE
Fix stale-if-error to properly use the stale value for the ttl

### DIFF
--- a/src/Guzzle/Plugin/Cache/DefaultCacheStorage.php
+++ b/src/Guzzle/Plugin/Cache/DefaultCacheStorage.php
@@ -54,7 +54,11 @@ class DefaultCacheStorage implements CacheStorageInterface
 
         if ($cacheControl = $response->getHeader('Cache-Control')) {
             $stale = $cacheControl->getDirective('stale-if-error');
-            $ttl += $stale == true ? $ttl : $stale;
+            if ($stale === true) {
+                $ttl += $ttl;
+            } else if (is_numeric($stale)) {
+                $ttl += $stale;
+            }
         }
 
         // Determine which manifest key should be used


### PR DESCRIPTION
Previously it always inferred `$stale == true` even when numeric and only added `$ttl`. This should fix this similarly to Guzzle 5's implementation to extend by the `$stale` value when it is numeric.
