### PR TITLE
Fix phpdoc typo

### DIFF
--- a/src/Guzzle/Common/Exception/ExceptionCollection.php
+++ b/src/Guzzle/Common/Exception/ExceptionCollection.php
@@ -41,7 +41,7 @@ class ExceptionCollection extends \Exception implements GuzzleException, \Iterat
      *
      * @param ExceptionCollection|\Exception $e Exception to add
      *
-     * @return ExceptionCollection;
+     * @return ExceptionCollection
      */
     public function add($e)
     {


### PR DESCRIPTION
This PHP Doc typo break some analysis tools(scrutinizer PHP Analyzer).
