### PR TITLE
Use late static binding when creating a new composite factory.

### DIFF
--- a/src/Guzzle/Service/Command/Factory/CompositeFactory.php
+++ b/src/Guzzle/Service/Command/Factory/CompositeFactory.php
@@ -28,7 +28,7 @@ class CompositeFactory implements \IteratorAggregate, \Countable, FactoryInterfa
         }
         $factories[] = new ConcreteClassFactory($client);
 
-        return new self($factories);
+        return new static($factories);
     }
 
     /**


### PR DESCRIPTION
I can work around this in a subclass by overriding getDefaultChain(), but it would be good for this to be fixed upstream.