### PR TITLE
Fix broken save_to examples

### DIFF
--- a/docs/http-client/request.rst
+++ b/docs/http-client/request.rst
@@ -60,10 +60,10 @@ option of a request:
 .. code-block:: php
 
     // Send the response body to a file
-    $request = $client->get('http://test.com', array(), array('save_to' => '/path/to/file'));
+    $request = $client->get('http://test.com', array('save_to' => '/path/to/file'));
 
     // Send the response body to an fopen resource
-    $request = $client->get('http://test.com', array(), array('save_to' => fopen('/path/to/file', 'w')));
+    $request = $client->get('http://test.com', array('save_to' => fopen('/path/to/file', 'w')));
 
 HEAD requests
 ~~~~~~~~~~~~~


### PR DESCRIPTION
The extra empty array is received as options and the actual options (containing save_to) is discarded in __call in 6.0.  It runs the request and never saves the file (and gives no error).