### PR TITLE
Fix more broken save_to examples

### DIFF
--- a/docs/http-client/request.rst
+++ b/docs/http-client/request.rst
@@ -465,10 +465,9 @@ Here's an example of using request options:
 
 .. code-block:: php
 
-    $request = $this->client->get('http://example.com/large.mov', array(), array(
+    $request = $this->client->get('http://example.com/large.mov', array(
         'save_to' => '/tmp/large_file.mov'
     ));
-    $request->send();
     var_export(file_exists('/tmp/large_file.mov'));
     // >>> true
 


### PR DESCRIPTION
Extra empty array is actually options in Request::__call.  Never saves file.  send() is unnecessary in 6.0 since get() returns a Psr7 response.