### PR TITLE
Handle the fact that isFresh() may return null

### DIFF
--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -791,10 +791,10 @@ class Response extends AbstractMessage implements \Serializable
         if ($header = $this->getHeader('Cache-Control')) {
             // s-max-age, then max-age, then Expires
             if ($age = $header->getDirective('s-maxage')) {
-                return $age;
+                return intval($age);
             }
             if ($age = $header->getDirective('max-age')) {
-                return $age;
+                return intval($age);
             }
         }
 
@@ -808,7 +808,7 @@ class Response extends AbstractMessage implements \Serializable
     /**
      * Check if the response is considered fresh.
      *
-     * A response is considered fresh when its age is less than or equal to the freshness lifetime (maximum age) of the
+     * A response is considered fresh when its age is less than the freshness lifetime (maximum age) of the
      * response.
      *
      * @return bool|null
@@ -817,7 +817,7 @@ class Response extends AbstractMessage implements \Serializable
     {
         $fresh = $this->getFreshness();
 
-        return $fresh === null ? null : $fresh >= 0;
+        return $fresh === null ? null : $fresh > 0;
     }
 
     /**
@@ -845,7 +845,7 @@ class Response extends AbstractMessage implements \Serializable
         $maxAge = $this->getMaxAge();
         $age = $this->calculateAge();
 
-        return $maxAge && $age ? ($maxAge - $age) : null;
+        return is_int($maxAge) && is_int($age) ? ($maxAge - $age) : null;
     }
 
     /**

--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -790,10 +790,15 @@ class Response extends AbstractMessage implements \Serializable
     {
         if ($header = $this->getHeader('Cache-Control')) {
             // s-max-age, then max-age, then Expires
-            if ($age = $header->getDirective('s-maxage')) {
+            $age = $header->getDirective('s-maxage');
+
+            if ($age !== null) {
                 return intval($age);
             }
-            if ($age = $header->getDirective('max-age')) {
+
+            $age = $header->getDirective('max-age');
+
+            if ($age !== null) {
                 return intval($age);
             }
         }

--- a/src/Guzzle/Plugin/Cache/CachePlugin.php
+++ b/src/Guzzle/Plugin/Cache/CachePlugin.php
@@ -238,7 +238,7 @@ class CachePlugin implements EventSubscriberInterface
         }
 
         // Check the response's max-age header
-        if ($response->isFresh() === false) {
+        if ($response->isFresh() !== true) {
             $maxStale = $reqc ? $reqc->getDirective('max-stale') : null;
             if (null !== $maxStale) {
                 if ($maxStale !== true && $response->getFreshness() < (-1 * $maxStale)) {
@@ -343,7 +343,7 @@ class CachePlugin implements EventSubscriberInterface
             $response->setHeader('X-Cache', $xcache);
         }
 
-        if ($response->isFresh() === false) {
+        if ($response->isFresh() !== true) {
             $response->addHeader('Warning', sprintf('110 GuzzleCache/%s "Response is stale"', Version::VERSION));
             if ($params['cache.hit'] === 'error') {
                 $response->addHeader('Warning', sprintf('111 GuzzleCache/%s "Revalidation failed"', Version::VERSION));

--- a/src/Guzzle/Plugin/Cache/CachePlugin.php
+++ b/src/Guzzle/Plugin/Cache/CachePlugin.php
@@ -238,7 +238,7 @@ class CachePlugin implements EventSubscriberInterface
         }
 
         // Check the response's max-age header
-        if ($response->isFresh() !== true) {
+        if ($response->isFresh() === false) {
             $maxStale = $reqc ? $reqc->getDirective('max-stale') : null;
             if (null !== $maxStale) {
                 if ($maxStale !== true && $response->getFreshness() < (-1 * $maxStale)) {
@@ -343,7 +343,7 @@ class CachePlugin implements EventSubscriberInterface
             $response->setHeader('X-Cache', $xcache);
         }
 
-        if ($response->isFresh() !== true) {
+        if ($response->isFresh() === false) {
             $response->addHeader('Warning', sprintf('110 GuzzleCache/%s "Response is stale"', Version::VERSION));
             if ($params['cache.hit'] === 'error') {
                 $response->addHeader('Warning', sprintf('111 GuzzleCache/%s "Revalidation failed"', Version::VERSION));

--- a/tests/Guzzle/Tests/Http/Message/ResponseTest.php
+++ b/tests/Guzzle/Tests/Http/Message/ResponseTest.php
@@ -563,12 +563,13 @@ class ResponseTest extends \Guzzle\Tests\GuzzleTestCase
 
         $response->setHeader('Cache-Control', 'max-age=120');
         $response->setHeader('Age', 100);
+
         $this->assertEquals(20, $response->getFreshness());
         $this->assertTrue($response->isFresh());
 
         $response->setHeader('Age', 120);
         $this->assertEquals(0, $response->getFreshness());
-        $this->assertTrue($response->isFresh());
+        $this->assertFalse($response->isFresh());
 
         $response->setHeader('Age', 150);
         $this->assertEquals(-30, $response->getFreshness());

--- a/tests/Guzzle/Tests/Plugin/Cache/DefaultCacheStorageTest.php
+++ b/tests/Guzzle/Tests/Plugin/Cache/DefaultCacheStorageTest.php
@@ -117,7 +117,7 @@ class DefaultCacheStorageTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertFalse(in_array('test', $this->readAttribute($cache['cache'], 'data')));
         $this->assertFalse(in_array($cache['serialized'], $this->readAttribute($cache['cache'], 'data')));
         $this->assertEquals(
-            array('DoctrineNamespaceCacheKey[]'),
+            array(),
             array_keys($this->readAttribute($cache['cache'], 'data'))
         );
     }


### PR DESCRIPTION
I'm not sure if this project is still being maintained, but I suspect guzzle3 is still the only choice out there for people using PHP v5.3. 

The issue here is that `isFresh` returns either a boolean or `null`, so checking for `false` is not sufficient. This causes guzzle to erroneously cache responses-- in my case we have `Cache-Control: max-age=0` and `Age: 0` being specified on responses, and guzzle is choosing to cache.
