### PR TITLE
Allow Symfony3 Event-Dispatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,23 @@ php:
   - 5.6
   - hhvm
 
+env:
+  global:
+    - SYMFONY_VERSION="~2.1"
+
+matrix:
+  include:
+    - php: 5.5
+      env: SYMFONY_VERSION="~3.0"
+    - php: 5.6
+      env: SYMFONY_VERSION="~3.0"
+
 before_script:
   - curl --version
   - pecl install uri_template-beta || echo "pecl uri_template not available"
   - composer self-update
+  - composer require symfony/event-dispatcher:${SYMFONY_VERSION} --no-update
+  - composer require symfony/class-loader:${SYMFONY_VERSION} --no-update
   - composer install --no-interaction --prefer-source --dev
   - ~/.nvm/nvm.sh install v0.6.14
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "require": {
         "php": ">=5.3.3",
         "ext-curl": "*",
-        "symfony/event-dispatcher": "~2.1"
+        "symfony/event-dispatcher": "~2.1|~3.0"
     },
 
     "autoload": {
@@ -66,7 +66,7 @@
 
     "require-dev": {
         "doctrine/cache": "~1.3",
-        "symfony/class-loader": "~2.1",
+        "symfony/class-loader": "~2.1|~3.0",
         "monolog/monolog": "~1.0",
         "psr/log": "~1.0",
         "zendframework/zend-cache": "2.*,<2.3",

--- a/src/Guzzle/Common/AbstractHasDispatcher.php
+++ b/src/Guzzle/Common/AbstractHasDispatcher.php
@@ -37,7 +37,13 @@ class AbstractHasDispatcher implements HasDispatcherInterface
 
     public function dispatch($eventName, array $context = array())
     {
-        return $this->getEventDispatcher()->dispatch($eventName, new Event($context));
+        $dispatcher = $this->getEventDispatcher();
+
+        $event = new Event($context);
+        $event->setDispatcher($dispatcher);
+        $event->setName($eventName);
+
+        return $dispatcher->dispatch($eventName, $event);
     }
 
     public function addSubscriber(EventSubscriberInterface $subscriber)

--- a/src/Guzzle/Common/Event.php
+++ b/src/Guzzle/Common/Event.php
@@ -3,6 +3,8 @@
 namespace Guzzle\Common;
 
 use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Default event for Guzzle notifications
@@ -11,6 +13,16 @@ class Event extends SymfonyEvent implements ToArrayInterface, \ArrayAccess, \Ite
 {
     /** @var array */
     private $context;
+
+    /**
+     * @var EventDispatcher that dispatched this event
+     */
+    private $dispatcher;
+
+    /**
+     * @var string This event's name
+     */
+    private $name;
 
     /**
      * @param array $context Contextual information
@@ -48,5 +60,53 @@ class Event extends SymfonyEvent implements ToArrayInterface, \ArrayAccess, \Ite
     public function toArray()
     {
         return $this->context;
+    }
+
+    /**
+     * Stores the EventDispatcher that dispatches this Event.
+     *
+     * @param EventDispatcherInterface $dispatcher
+     *
+     * @deprecated
+     */
+    public function setDispatcher(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * Returns the EventDispatcher that dispatches this Event.
+     *
+     * @return EventDispatcherInterface
+     *
+     * @deprecated
+     */
+    public function getDispatcher()
+    {
+        return $this->dispatcher;
+    }
+
+    /**
+     * Gets the event's name.
+     *
+     * @return string
+     *
+     * @deprecated
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Sets the event's name property.
+     *
+     * @param string $name The event name.
+     *
+     * @deprecated
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
     }
 }

--- a/src/Guzzle/Http/Curl/CurlMulti.php
+++ b/src/Guzzle/Http/Curl/CurlMulti.php
@@ -211,7 +211,14 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
             foreach ($this->requests as $request) {
                 ++$total;
                 $event['request'] = $request;
-                $request->getEventDispatcher()->dispatch(self::POLLING_REQUEST, $event);
+
+                $dispatcher = $request->getEventDispatcher();
+                $eventName = self::POLLING_REQUEST;
+
+                $event->setDispatcher($dispatcher);
+                $event->setName($eventName);
+
+                $dispatcher->dispatch($eventName, $event);
                 // The blocking variable just has to be non-falsey to block the loop
                 if ($request->getParams()->hasKey(self::BLOCKING)) {
                     ++$blocking;

--- a/src/Guzzle/Http/IoEmittingEntityBody.php
+++ b/src/Guzzle/Http/IoEmittingEntityBody.php
@@ -43,7 +43,13 @@ class IoEmittingEntityBody extends AbstractEntityBodyDecorator implements HasDis
 
     public function dispatch($eventName, array $context = array())
     {
-        return $this->getEventDispatcher()->dispatch($eventName, new Event($context));
+        $dispatcher = $this->getEventDispatcher();
+
+        $event = new Event($context);
+        $event->setDispatcher($dispatcher);
+        $event->setName($eventName);
+
+        return $dispatcher->dispatch($eventName, $event);
     }
 
     /**


### PR DESCRIPTION
As disussed on Twitter, @mtdowling would consider a non-breaking Symfony 3 PR.

This adds the deprecated methods back to the Guzzle events and adds the name/dispatcher to events emitted by Guzzle or the AbstractDispatcher.
Tests are run on 5.5+5.6 on both Symfony 2 and 3.

Test are currently failing because of Doctrine, but unrelated to this PR.
