### PR TITLE
Update tests to allow for Doctrine Cache >= 1.6.0 internal changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     },
 
     "require-dev": {
-        "doctrine/cache": "~1.4",
+        "doctrine/cache": "~1.4,>=1.4.3",
         "symfony/class-loader": "~2.1",
         "monolog/monolog": "~1.0",
         "psr/log": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     },
 
     "require-dev": {
-        "doctrine/cache": "~1.3",
+        "doctrine/cache": "~1.4.3",
         "symfony/class-loader": "~2.1",
         "monolog/monolog": "~1.0",
         "psr/log": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     },
 
     "require-dev": {
-        "doctrine/cache": "~1.4.3",
+        "doctrine/cache": "~1.4",
         "symfony/class-loader": "~2.1",
         "monolog/monolog": "~1.0",
         "psr/log": "~1.0",

--- a/tests/Guzzle/Tests/Plugin/Cache/DefaultCacheStorageTest.php
+++ b/tests/Guzzle/Tests/Plugin/Cache/DefaultCacheStorageTest.php
@@ -142,7 +142,7 @@ class DefaultCacheStorageTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertFalse(in_array('test', $this->readAttribute($cache['cache'], 'data')));
         $this->assertFalse(in_array($cache['serialized'], $this->readAttribute($cache['cache'], 'data')));
         $this->assertEquals(
-            array('DoctrineNamespaceCacheKey[]'),
+            array(),
             array_keys($this->readAttribute($cache['cache'], 'data'))
         );
     }


### PR DESCRIPTION
I understand this library is deprecated, but it is still used by several other libraries I need to support.  I ran across this issue when updating Doctrine Cache from 1.5.4 to 1.6.0.  Since Doctrine Cache changed its' private `data` attribute and the `guzzle3` tests bypass scope and use that private attribute directly, this patch only modifies the tests themselves.
